### PR TITLE
Mo branch

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -4,6 +4,7 @@ import { BrowserRouter, Route, Redirect, Switch } from 'react-router-dom';
 import Login from './pages/Login/Login';
 import Signup from './pages/SignUp/SignUp';
 import Dashboard from './pages/Dashboard/Dashboard';
+import Profile from './pages/Profile/Profile';
 import { AuthProvider } from './context/useAuthContext';
 import { SocketProvider } from './context/useSocketContext';
 import { SnackBarProvider } from './context/useSnackbarContext';
@@ -18,6 +19,9 @@ function App(): JSX.Element {
           <AuthProvider>
             <SocketProvider>
               <Switch>
+                <Route exact path="/profile" component={Profile}>
+                  <Profile />
+                </Route>
                 <Route exact path="/login" component={Login} />
                 <Route exact path="/signup" component={Signup} />
                 <Route exact path="/dashboard">

--- a/client/src/components/ChatSideBanner/ChatSideBanner.tsx
+++ b/client/src/components/ChatSideBanner/ChatSideBanner.tsx
@@ -7,6 +7,7 @@ import { User } from '../../interface/User';
 import AvatarDisplay from '../AvatarDisplay/AvatarDisplay';
 import Search from '../Search/Search';
 import AuthMenu from '../AuthMenu/AuthMenu';
+import { Link } from '@material-ui/core';
 
 interface Props {
   loggedInUser: User;
@@ -29,7 +30,9 @@ const ChatSideBanner = ({ loggedInUser }: Props): JSX.Element => {
   return (
     <Grid className={classes.chatSideBanner}>
       <Box className={classes.userPanel}>
-        <AvatarDisplay loggedIn user={loggedInUser} />
+        <Link href="/profile">
+          <AvatarDisplay loggedIn user={loggedInUser} />
+        </Link>
         <Typography className={classes.userText} variant="h5">
           {loggedInUser.username}
         </Typography>

--- a/client/src/context/useAuthContext.tsx
+++ b/client/src/context/useAuthContext.tsx
@@ -25,7 +25,9 @@ export const AuthProvider: FunctionComponent = ({ children }): JSX.Element => {
   const updateLoginContext = useCallback(
     (data: AuthApiDataSuccess) => {
       setLoggedInUser(data.user);
-      history.push('/dashboard');
+      if (history.location.pathname === '/login' || history.location.pathname === '/register') {
+        history.push('/dashboard');
+      }
     },
     [history],
   );
@@ -46,7 +48,10 @@ export const AuthProvider: FunctionComponent = ({ children }): JSX.Element => {
       await loginWithCookies().then((data: AuthApiData) => {
         if (data.success) {
           updateLoginContext(data.success);
-          history.push('/dashboard');
+          console.log(history);
+          if (history.location.pathname === '/login' || history.location.pathname === '/register') {
+            history.push('/dashboard');
+          }
         } else {
           // don't need to provide error feedback as this just means user doesn't have saved cookies or the cookies have not been authenticated on the backend
           setLoggedInUser(null);

--- a/client/src/pages/Profile/Profile.tsx
+++ b/client/src/pages/Profile/Profile.tsx
@@ -1,0 +1,39 @@
+import Grid from '@material-ui/core/Grid';
+import CircularProgress from '@material-ui/core/CircularProgress';
+import { useAuth } from '../../context/useAuthContext';
+import { useHistory } from 'react-router-dom';
+import { Box, Container, Link, MenuItem, MenuList } from '@material-ui/core';
+import ProfilePhoto from './ProfilePhoto/ProfilePhoto';
+
+export default function Profile(): JSX.Element {
+  const { loggedInUser } = useAuth();
+
+  const history = useHistory();
+
+  if (loggedInUser === undefined) return <CircularProgress />;
+  if (!loggedInUser) {
+    history.push('/login');
+    // loading for a split seconds until history.push works
+    return <CircularProgress />;
+  }
+
+  return (
+    <Container>
+      <Grid container spacing={4} alignItems="center">
+        <Grid item xs={6} sm={3}>
+          <Box>
+            <MenuList>
+              <MenuItem>
+                <Link href="#">Profile photo</Link>
+              </MenuItem>
+              <MenuItem>My account</MenuItem>
+            </MenuList>
+          </Box>
+        </Grid>
+        <Grid item xs={12} sm={6} container direction="column" justify="space-evenly" alignItems="center">
+          <ProfilePhoto />
+        </Grid>
+      </Grid>
+    </Container>
+  );
+}

--- a/client/src/pages/Profile/ProfilePhoto/ProfilePhoto.tsx
+++ b/client/src/pages/Profile/ProfilePhoto/ProfilePhoto.tsx
@@ -1,0 +1,61 @@
+import Grid from '@material-ui/core/Grid';
+import { Avatar, Button, Typography } from '@material-ui/core';
+import useStyles from './useStyles';
+import { useState } from 'react';
+import DeleteIcon from '@material-ui/icons/Delete';
+import { useSnackBar } from '../../../context/useSnackbarContext';
+
+export default function ProfilePhoto(): JSX.Element {
+  const [photo, setPhoto] = useState<string | undefined>('');
+  const classes = useStyles();
+  const { updateSnackBarMessage } = useSnackBar();
+
+  const changePhoto = (file: File | null) => {
+    if (file) {
+      const reader = new FileReader();
+      reader.readAsDataURL(file);
+      reader.onloadend = () => {
+        if (reader.result) {
+          setPhoto(reader.result.toString());
+          updateSnackBarMessage('new profile photo added');
+        }
+      };
+    }
+  };
+  const deletePhoto = () => {
+    setPhoto('');
+    updateSnackBarMessage('profile photo deleted');
+  };
+
+  return (
+    <Grid item>
+      <Typography align="center" variant="h3">
+        Profile photo
+      </Typography>
+      <Avatar alt="Remy Sharp" src={photo!.toString()} className={classes.photo} />
+      <input
+        onChange={(e) => {
+          const { target } = e;
+          if (target) {
+            if (target.files) {
+              changePhoto(target.files[0]);
+            }
+          }
+        }}
+        className={classes.input}
+        accept="image/*"
+        id="contained-button-file"
+        type="file"
+      />
+      <label htmlFor="contained-button-file">
+        <Button size="large" variant="outlined" color="secondary" component="span">
+          Upload a file from your device
+        </Button>
+      </label>
+      <br />
+      <Button onClick={deletePhoto} startIcon={<DeleteIcon />} className={classes.delete_button}>
+        delete photo
+      </Button>
+    </Grid>
+  );
+}

--- a/client/src/pages/Profile/ProfilePhoto/useStyles.ts
+++ b/client/src/pages/Profile/ProfilePhoto/useStyles.ts
@@ -1,0 +1,27 @@
+import { makeStyles } from '@material-ui/core/styles';
+
+const useStyles = makeStyles((theme) => ({
+  root: {
+    width: '100%', // Fix IE 11 issue.
+    marginTop: theme.spacing(2),
+  },
+  photo: {
+    width: 100,
+    height: 100,
+    alignSelf: 'center',
+    alignContent: 'center',
+    margin: 55,
+    display: 'flex',
+  },
+  delete_button: {
+    alignSelf: 'center',
+    alignContent: 'center',
+    margin: 60,
+    display: 'flex',
+  },
+  input: {
+    display: 'none',
+  },
+}));
+
+export default useStyles;

--- a/client/src/pages/Profile/useStyles.ts
+++ b/client/src/pages/Profile/useStyles.ts
@@ -1,0 +1,12 @@
+import { makeStyles } from '@material-ui/core/styles';
+
+const useStyles = makeStyles(() => ({
+  root: {
+    minHeight: '100vh',
+    '& .MuiInput-underline:before': {
+      borderBottom: '1.2px solid rgba(0, 0, 0, 0.2)',
+    },
+  },
+}));
+
+export default useStyles;


### PR DESCRIPTION
### What this PR does (required):
- added only the UI needed for the user to add/delete his profile photo
- modified the useAuthContext 

file to only redirect to the dashboard if the user has just logged in or registered
- added a new route for the profile page
- added link in the dashboard for the profile page

### Screenshots / Videos (required):
<img width="1336" alt="Screen Shot 2021-08-25 at 12 34 53 AM" src="https://user-images.githubusercontent.com/29197126/130698911-c7678909-2d7b-455a-99ca-dc0deff75eb2.png">

### Any information needed to test this feature (required):
- sign up as a user and go to the dashboard, then click on the default profile photo on the top left. you should be redirected to a page where you can add or delete photos 

### Any issues with the current functionality (optional):
- I'm not sure if I added a profile page in a proper way and if it can cause problems for other pull requests. 
