### PR TITLE
adding Notifications in the backend

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -13,6 +13,7 @@ const authRouter = require("./routes/auth");
 const userRouter = require("./routes/user");
 const profileRouter = require("./routes/profile");
 const requestRouter = require("./routes/request");
+const notificationRouter = require("./routes/notification");
 
 const { json, urlencoded } = express;
 
@@ -47,6 +48,7 @@ app.use("/auth", authRouter);
 app.use("/users", userRouter);
 app.use("/profile", profileRouter);
 app.use("/request", requestRouter);
+app.use("/notification", notificationRouter);
 
 if (process.env.NODE_ENV === "production") {
   app.use(express.static(path.join(__dirname, "/client/build")));

--- a/server/controllers/notification.js
+++ b/server/controllers/notification.js
@@ -27,5 +27,5 @@ exports.markNotificationAsRead = asyncHandler(async (req, res, next) => {
   });
   res.sendStatus(200);
 });
-exports.getAllUnreadNotifications = asyncHandler(async (req, res, next) => {});
+exports.getAllNotifications = asyncHandler(async (req, res, next) => {});
 exports.getUnreadNotifications = asyncHandler(async (req, res, next) => {});

--- a/server/controllers/notification.js
+++ b/server/controllers/notification.js
@@ -14,8 +14,18 @@ exports.createNotification = asyncHandler(async (req, res, next) => {
     title: title,
     description: description,
   });
-  res.status(200).json(newNotification);
+  res.status(201).json(newNotification);
 });
-exports.markNotificationAsRead = asyncHandler(async (req, res, next) => {});
+exports.markNotificationAsRead = asyncHandler(async (req, res, next) => {
+  const { id } = req.params;
+  const notification = await Notification.findById(id);
+  if (!notification.userId.equals(req.user.id)) {
+    return res.sendStatus(403);
+  }
+  const seenNotification = await Notification.findByIdAndUpdate(id, {
+    read: true,
+  });
+  res.sendStatus(200);
+});
 exports.getAllUnreadNotifications = asyncHandler(async (req, res, next) => {});
 exports.getUnreadNotifications = asyncHandler(async (req, res, next) => {});

--- a/server/controllers/notification.js
+++ b/server/controllers/notification.js
@@ -1,0 +1,6 @@
+const asyncHandler = require("express-async-handler");
+
+exports.createNotification = asyncHandler(async (req, res, next) => {});
+exports.markNotificationAsRead = asyncHandler(async (req, res, next) => {});
+exports.getAllUnreadNotifications = asyncHandler(async (req, res, next) => {});
+exports.getUnreadNotifications = asyncHandler(async (req, res, next) => {});

--- a/server/controllers/notification.js
+++ b/server/controllers/notification.js
@@ -1,6 +1,21 @@
 const asyncHandler = require("express-async-handler");
+const Notification = require("../models/Notification");
+const User = require("../models/User");
 
-exports.createNotification = asyncHandler(async (req, res, next) => {});
+exports.createNotification = asyncHandler(async (req, res, next) => {
+  const { userReceivedId, notificationType, title, description } = req.body;
+  const user = await User.findById(userReceivedId);
+  if (!user) {
+    return res.sendStatus(400);
+  }
+  const newNotification = await Notification.create({
+    userId: userReceivedId,
+    notificationType: notificationType,
+    title: title,
+    description: description,
+  });
+  res.status(200).json(newNotification);
+});
 exports.markNotificationAsRead = asyncHandler(async (req, res, next) => {});
 exports.getAllUnreadNotifications = asyncHandler(async (req, res, next) => {});
 exports.getUnreadNotifications = asyncHandler(async (req, res, next) => {});

--- a/server/controllers/notification.js
+++ b/server/controllers/notification.js
@@ -27,5 +27,11 @@ exports.markNotificationAsRead = asyncHandler(async (req, res, next) => {
   });
   res.sendStatus(200);
 });
-exports.getAllNotifications = asyncHandler(async (req, res, next) => {});
+exports.getAllNotifications = asyncHandler(async (req, res, next) => {
+  const loggedInUserId = req.user.id;
+  const notifications = await Notification.find({
+    userId: loggedInUserId,
+  }).sort("createdAt");
+  res.status(200).json(notifications);
+});
 exports.getUnreadNotifications = asyncHandler(async (req, res, next) => {});

--- a/server/controllers/notification.js
+++ b/server/controllers/notification.js
@@ -34,4 +34,11 @@ exports.getAllNotifications = asyncHandler(async (req, res, next) => {
   }).sort("createdAt");
   res.status(200).json(notifications);
 });
-exports.getUnreadNotifications = asyncHandler(async (req, res, next) => {});
+exports.getUnreadNotifications = asyncHandler(async (req, res, next) => {
+  const loggedInUserId = req.user.id;
+  const notifications = await Notification.find({
+    userId: loggedInUserId,
+    read: false,
+  }).sort("createdAt");
+  res.status(200).json(notifications);
+});

--- a/server/controllers/notification.js
+++ b/server/controllers/notification.js
@@ -6,7 +6,7 @@ exports.createNotification = asyncHandler(async (req, res, next) => {
   const { userReceivedId, notificationType, title, description } = req.body;
   const user = await User.findById(userReceivedId);
   if (!user) {
-    return res.sendStatus(400);
+    return res.sendStatus(404);
   }
   const newNotification = await Notification.create({
     userId: userReceivedId,
@@ -18,8 +18,16 @@ exports.createNotification = asyncHandler(async (req, res, next) => {
 });
 exports.markNotificationAsRead = asyncHandler(async (req, res, next) => {
   const { id } = req.params;
+  const loggedInUserId = req.user.id;
+  const user = await User.findById(loggedInUserId);
+  if (!user) {
+    return res.sendStatus(404);
+  }
   const notification = await Notification.findById(id);
-  if (!notification.userId.equals(req.user.id)) {
+  if (!notification) {
+    return res.sendStatus(404);
+  }
+  if (!notification.userId.equals(loggedInUserId)) {
     return res.sendStatus(403);
   }
   const seenNotification = await Notification.findByIdAndUpdate(id, {
@@ -36,6 +44,10 @@ exports.getAllNotifications = asyncHandler(async (req, res, next) => {
 });
 exports.getUnreadNotifications = asyncHandler(async (req, res, next) => {
   const loggedInUserId = req.user.id;
+  const user = await User.findById(loggedInUserId);
+  if (!user) {
+    return res.sendStatus(404);
+  }
   const notifications = await Notification.find({
     userId: loggedInUserId,
     read: false,

--- a/server/models/Notification.js
+++ b/server/models/Notification.js
@@ -1,16 +1,20 @@
 const mongoose = require("mongoose");
 
-const notificationSchema = mongoose.Schema({
-  notificationType: {
-    type: String,
-    enum: ["success", "warning", "info", "confirmation"],
-    default: "info",
-    required: true,
+const notificationSchema = mongoose.Schema(
+  {
+    notificationType: {
+      type: String,
+      enum: ["success", "warning", "info", "confirmation"],
+      default: "info",
+    },
+    title: { type: String, required: true },
+    description: String,
+    read: { type: Boolean, default: false },
+    userId: {
+      type: mongoose.Schema.Types.ObjectId,
+    },
   },
-  title: { type: String, required: true },
-  description: Text,
-  read: { type: Boolean, default: false },
-  date: { type: Date, default: Date.now() },
-});
+  { timestamps: true }
+);
 
 module.exports = Request = mongoose.model("notification", notificationSchema);

--- a/server/models/Notification.js
+++ b/server/models/Notification.js
@@ -12,7 +12,7 @@ const notificationSchema = mongoose.Schema(
     read: { type: Boolean, default: false },
     userId: {
       type: mongoose.Schema.Types.ObjectId,
-      red: "user",
+      ref: "user",
     },
   },
   { timestamps: true }

--- a/server/models/Notification.js
+++ b/server/models/Notification.js
@@ -12,6 +12,7 @@ const notificationSchema = mongoose.Schema(
     read: { type: Boolean, default: false },
     userId: {
       type: mongoose.Schema.Types.ObjectId,
+      red: "user",
     },
   },
   { timestamps: true }

--- a/server/models/Notification.js
+++ b/server/models/Notification.js
@@ -1,0 +1,16 @@
+const mongoose = require("mongoose");
+
+const notificationSchema = mongoose.Schema({
+  notificationType: {
+    type: String,
+    enum: ["success", "warning", "info", "confirmation"],
+    default: "info",
+    required: true,
+  },
+  title: { type: String, required: true },
+  description: Text,
+  read: { type: Boolean, default: false },
+  date: { type: Date, default: Date.now() },
+});
+
+module.exports = Request = mongoose.model("notification", notificationSchema);

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -24,10 +24,18 @@ const userSchema = new mongoose.Schema({
     url: String,
     publicId: String,
   },
-  requests: [{
-    type: mongoose.Schema.Types.ObjectId, 
-    ref: "request"
-  }]
+  requests: [
+    {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "request",
+    },
+  ],
+  notifications: [
+    {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "notification",
+    },
+  ],
 });
 
 userSchema.methods.matchPassword = async function (enteredPassword) {

--- a/server/routes/notification.js
+++ b/server/routes/notification.js
@@ -1,6 +1,8 @@
 const express = require("express");
 const router = express.Router();
 const protect = require("../middleware/auth");
+const { validateCreateNotification } = require("../validate");
+
 const {
   createNotification,
   markNotificationAsRead,
@@ -8,7 +10,7 @@ const {
   getUnreadNotifications,
 } = require("../controllers/notification");
 
-router.route("/").post(protect, createNotification);
+router.route("/").post(protect, validateCreateNotification, createNotification);
 router.route("/seen/:id").post(protect, markNotificationAsRead);
 router.route("/all").get(protect, getAllNotifications);
 router.route("/all-unread").get(protect, getUnreadNotifications);

--- a/server/routes/notification.js
+++ b/server/routes/notification.js
@@ -8,7 +8,7 @@ const {
   getUnreadNotifications,
 } = require("../controllers/notification");
 
-router.route("/").get(protect, createNotification);
+router.route("/").post(protect, createNotification);
 router.route("/:id").post(protect, markNotificationAsRead);
 router.route("/all").get(protect, getAllUnreadNotifications);
 router.route("/all-unread").get(protect, getUnreadNotifications);

--- a/server/routes/notification.js
+++ b/server/routes/notification.js
@@ -11,7 +11,7 @@ const {
 } = require("../controllers/notification");
 
 router.route("/").post(protect, validateCreateNotification, createNotification);
-router.route("/seen/:id").post(protect, markNotificationAsRead);
+router.route("/seen/:id").put(protect, markNotificationAsRead);
 router.route("/all").get(protect, getAllNotifications);
 router.route("/all-unread").get(protect, getUnreadNotifications);
 

--- a/server/routes/notification.js
+++ b/server/routes/notification.js
@@ -4,13 +4,13 @@ const protect = require("../middleware/auth");
 const {
   createNotification,
   markNotificationAsRead,
-  getAllUnreadNotifications,
+  getAllNotifications,
   getUnreadNotifications,
 } = require("../controllers/notification");
 
 router.route("/").post(protect, createNotification);
 router.route("/seen/:id").post(protect, markNotificationAsRead);
-router.route("/all").get(protect, getAllUnreadNotifications);
+router.route("/all").get(protect, getAllNotifications);
 router.route("/all-unread").get(protect, getUnreadNotifications);
 
 module.exports = router;

--- a/server/routes/notification.js
+++ b/server/routes/notification.js
@@ -1,0 +1,16 @@
+const express = require("express");
+const router = express.Router();
+const protect = require("../middleware/auth");
+const {
+  createNotification,
+  markNotificationAsRead,
+  getAllUnreadNotifications,
+  getUnreadNotifications,
+} = require("../controllers/notification");
+
+router.route("/").get(protect, createNotification);
+router.route("/:id").post(protect, markNotificationAsRead);
+router.route("/all").get(protect, getAllUnreadNotifications);
+router.route("/all-unread").get(protect, getUnreadNotifications);
+
+module.exports = router;

--- a/server/routes/notification.js
+++ b/server/routes/notification.js
@@ -9,7 +9,7 @@ const {
 } = require("../controllers/notification");
 
 router.route("/").post(protect, createNotification);
-router.route("/:id").post(protect, markNotificationAsRead);
+router.route("/seen/:id").post(protect, markNotificationAsRead);
 router.route("/all").get(protect, getAllUnreadNotifications);
 router.route("/all-unread").get(protect, getUnreadNotifications);
 

--- a/server/validate.js
+++ b/server/validate.js
@@ -41,4 +41,12 @@ exports.validateCreateNotification = [
   ]),
   check("title").trim().escape().notEmpty(),
   check("description").trim().escape(),
+
+  (req, res, next) => {
+    const errors = validationResult(req);
+
+    if (!errors.isEmpty())
+      return res.status(400).json({ errors: errors.array() });
+    next();
+  },
 ];

--- a/server/validate.js
+++ b/server/validate.js
@@ -38,6 +38,7 @@ exports.validateCreateNotification = [
     "warning",
     "info",
     "confirmation",
+    null,
   ]),
   check("title").trim().escape().notEmpty(),
   check("description").trim().escape(),

--- a/server/validate.js
+++ b/server/validate.js
@@ -7,7 +7,7 @@ exports.validateRegister = [
     "password",
     "Please enter a password with 6 or more characters"
   ).isLength({
-    min: 6
+    min: 6,
   }),
   (req, res, next) => {
     const errors = validationResult(req);
@@ -16,7 +16,7 @@ exports.validateRegister = [
     if (!errors.isEmpty())
       return res.status(400).json({ errors: errors.array() });
     next();
-  }
+  },
 ];
 
 exports.validateLogin = [
@@ -28,5 +28,17 @@ exports.validateLogin = [
     if (!errors.isEmpty())
       return res.status(400).json({ errors: errors.array() });
     next();
-  }
+  },
+];
+
+exports.validateCreateNotification = [
+  check("userReceivedId").notEmpty().isString(),
+  check("notificationType").isIn([
+    "success",
+    "warning",
+    "info",
+    "confirmation",
+  ]),
+  check("title").trim().escape().notEmpty(),
+  check("description").trim().escape(),
 ];


### PR DESCRIPTION
### What this PR does (required):
- adds a `Notification` schema that is referenced in the User model
- adds routes to 
    - create notification
    - mark notification as read by user
    - get all notifications for user
    - get all  notifications unread by user

- the notification types I'm proposing  are 
     - `success` : can include a user's adoption request is accepted. or changed    
     - `warning`: can include warnings for the user  
     - `confirmation`: could be for confirming an adoption request, confirming and data the user had added
     - `info`: this should be the default for app information 


### Any information needed to test this feature (required):
- test the 4 routes added for notifications from the back-end


