### PR TITLE
Paginate notifications

### DIFF
--- a/client/src/components/NavBar/NotificationsMenu/NotificationsMenu.tsx
+++ b/client/src/components/NavBar/NotificationsMenu/NotificationsMenu.tsx
@@ -27,7 +27,7 @@ export default function NotificationsMenu(): JSX.Element {
   const handleClose = () => {
     setAnchorEl(null);
   };
-  const [notifications, setNotifications] = useState<[Notification]>();
+  const [notifications, setNotifications] = useState<Notification[]>();
   useEffect(() => {
     async function fetchNotifications() {
       if (loggedInUser) {

--- a/client/src/components/NavBar/NotificationsMenu/NotificationsMenu.tsx
+++ b/client/src/components/NavBar/NotificationsMenu/NotificationsMenu.tsx
@@ -123,9 +123,9 @@ export default function NotificationsMenu(): JSX.Element {
           )}
           {notifications && notifications.length >= 1 && <NotificationsMenuItems notifications={notifications} />}
           <MenuItem component={routerLink} to={'/notifications'}>
-            <Box textAlign="center" width={150}>
-              <ListItemText> show all notifications</ListItemText>
-            </Box>
+            <ListItemText>
+              <Box textAlign="center">show all notifications</Box>
+            </ListItemText>
           </MenuItem>
         </Box>
       </Menu>

--- a/client/src/components/NavBar/NotificationsMenu/NotificationsMenuItems/NotificationsMenuItems.tsx
+++ b/client/src/components/NavBar/NotificationsMenu/NotificationsMenuItems/NotificationsMenuItems.tsx
@@ -3,7 +3,7 @@ import { Typography, MenuItem, Paper, ListItemText, ListItemAvatar, Avatar, Box 
 import { Notification } from '../../../../interface/Notification';
 
 interface Props {
-  notifications: [Notification];
+  notifications: Notification[];
 }
 
 export default function NotificationsMenuItems({ notifications }: Props): JSX.Element {

--- a/client/src/helpers/APICalls/Notification.ts
+++ b/client/src/helpers/APICalls/Notification.ts
@@ -11,7 +11,7 @@ const postFetchOptions: FetchOptions = {
 };
 
 const getAllNotifications = async (lastId?: string): Promise<Notification[]> => {
-  const res = await (`/notification/all?id=${lastId}`, fetchOptions)
+  const res = await fetch(`/notification/all?id=${lastId}`, fetchOptions);
   return res.json();
 };
 

--- a/client/src/helpers/APICalls/Notification.ts
+++ b/client/src/helpers/APICalls/Notification.ts
@@ -10,8 +10,8 @@ const postFetchOptions: FetchOptions = {
   credentials: 'include',
 };
 
-const getAllNotifications = async (): Promise<[Notification]> => {
-  return await fetch(`/notification/all`, fetchOptions)
+const getAllNotifications = async (lastId?: string): Promise<[Notification]> => {
+  return await fetch(`/notification/all?id=${lastId}`, fetchOptions)
     .then((res) => res.json())
     .catch(() => ({ error: { message: 'Unable to connect to server. Please try again' } }));
 };

--- a/client/src/helpers/APICalls/Notification.ts
+++ b/client/src/helpers/APICalls/Notification.ts
@@ -10,13 +10,13 @@ const postFetchOptions: FetchOptions = {
   credentials: 'include',
 };
 
-const getAllNotifications = async (lastId?: string): Promise<[Notification]> => {
+const getAllNotifications = async (lastId?: string): Promise<Notification[]> => {
   return await fetch(`/notification/all?id=${lastId}`, fetchOptions)
     .then((res) => res.json())
     .catch(() => ({ error: { message: 'Unable to connect to server. Please try again' } }));
 };
 
-const getAllUnreadNotifications = async (): Promise<[Notification]> => {
+const getAllUnreadNotifications = async (): Promise<Notification[]> => {
   return await fetch(`/notification/all-unread`, fetchOptions)
     .then((res) => res.json())
     .catch(() => ({ error: { message: 'Unable to connect to server. Please try again' } }));

--- a/client/src/pages/AllNotifiactions/AllNotifications.tsx
+++ b/client/src/pages/AllNotifiactions/AllNotifications.tsx
@@ -1,5 +1,15 @@
 import { useAuth } from '../../context/useAuthContext';
-import { Typography, Paper, ListItemText, Box, MenuList, ListItemAvatar, Avatar, MenuItem, Button } from '@material-ui/core';
+import {
+  Typography,
+  Paper,
+  ListItemText,
+  Box,
+  MenuList,
+  ListItemAvatar,
+  Avatar,
+  MenuItem,
+  Button,
+} from '@material-ui/core';
 import React, { useEffect, useState } from 'react';
 import { getAllNotifications, markBatchAsRead } from '../../helpers/APICalls/Notification';
 import { Notification } from '../../interface/Notification';
@@ -24,7 +34,9 @@ export default function AllNotifications(): JSX.Element {
     }
 
     fetchNotifications();
+  }, [loggedInUser]);
 
+  useEffect(() => {
     async function markAllNotificationsAsRead() {
       const notificationIds: string[] = [];
       notifications?.forEach((notification) => {
@@ -37,7 +49,7 @@ export default function AllNotifications(): JSX.Element {
       }
     }
     markAllNotificationsAsRead();
-  }, [notifications, loggedInUser]);
+  }, [notifications]);
 
   return (
     <Box marginBottom={'11%'} marginTop={'10%'} alignItems={'center'} marginLeft={'10%'} marginRight={'10%'}>

--- a/client/src/pages/AllNotifiactions/AllNotifications.tsx
+++ b/client/src/pages/AllNotifiactions/AllNotifications.tsx
@@ -1,6 +1,6 @@
 import { useAuth } from '../../context/useAuthContext';
-import { Typography, Paper, ListItemText, Box, MenuList } from '@material-ui/core';
-import React, { useEffect, useState } from 'react';
+import { Typography, Paper, ListItemText, Box, MenuList, Button } from '@material-ui/core';
+import React, { useEffect, useLayoutEffect, useState } from 'react';
 import { getAllNotifications, markBatchAsRead } from '../../helpers/APICalls/Notification';
 import { Notification } from '../../interface/Notification';
 import NotificationsMenuItems from '../../components/NavBar/NotificationsMenu/NotificationsMenuItems/NotificationsMenuItems';
@@ -9,15 +9,25 @@ export default function AllNotifications(): JSX.Element {
   const { loggedInUser } = useAuth();
 
   const [notifications, setNotifications] = useState<[Notification]>();
+  const [lastId, setLastId] = useState<string>();
+  const [isAllShown, setIsAllShown] = useState<boolean>(false);
   useEffect(() => {
     async function fetchNotifications() {
       if (loggedInUser) {
         const fetchedNotifications = await getAllNotifications();
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        //@ts-ignore
         setNotifications(fetchedNotifications);
+        if (fetchedNotifications.length > 1) {
+          setLastId(fetchedNotifications[fetchedNotifications.length - 1]._id);
+        }
       }
     }
-    fetchNotifications();
 
+    fetchNotifications();
+  }, [loggedInUser]);
+
+  useLayoutEffect(() => {
     async function markAllNotificationsAsRead() {
       const notificationIds: string[] = [];
       notifications?.forEach((notification) => {
@@ -29,11 +39,12 @@ export default function AllNotifications(): JSX.Element {
         await markBatchAsRead(notificationIds);
       }
     }
+
     markAllNotificationsAsRead();
-  }, [notifications, loggedInUser]);
+  }, [notifications]);
 
   return (
-    <Box marginTop={'10%'} alignItems={'center'} marginLeft={'10%'} marginRight={'10%'}>
+    <Box marginBottom={'11%'} marginTop={'10%'} alignItems={'center'} marginLeft={'10%'} marginRight={'10%'}>
       <Paper>
         <MenuList>
           <ListItemText
@@ -47,6 +58,30 @@ export default function AllNotifications(): JSX.Element {
           />
           {notifications && <NotificationsMenuItems notifications={notifications} />}
         </MenuList>
+        <Box marginLeft={'30%'} textAlign="center" marginRight={'30%'} fontSize={12} fontWeight={600} color="#000000">
+          {isAllShown ? (
+            <Button>nothing more to show</Button>
+          ) : (
+            <Button
+              color="primary"
+              variant="outlined"
+              onClick={async () => {
+                const fetchedNotifications = await getAllNotifications(lastId);
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                //@ts-ignore
+                setNotifications((old) => [...old, ...fetchedNotifications]);
+
+                if (fetchedNotifications.length > 1) {
+                  setLastId(fetchedNotifications[fetchedNotifications.length - 1]._id);
+                } else {
+                  setIsAllShown(true);
+                }
+              }}
+            >
+              show more
+            </Button>
+          )}
+        </Box>
       </Paper>
     </Box>
   );

--- a/client/src/pages/AllNotifiactions/AllNotifications.tsx
+++ b/client/src/pages/AllNotifiactions/AllNotifications.tsx
@@ -15,6 +15,7 @@ import { getAllNotifications, markBatchAsRead } from '../../helpers/APICalls/Not
 import { Notification } from '../../interface/Notification';
 import NotificationsMenuItems from '../../components/NavBar/NotificationsMenu/NotificationsMenuItems/NotificationsMenuItems';
 import { Skeleton } from '@material-ui/lab';
+import { useSocket } from '../../context/useSocketContext';
 
 export default function AllNotifications(): JSX.Element {
   const { loggedInUser } = useAuth();
@@ -22,6 +23,8 @@ export default function AllNotifications(): JSX.Element {
   const [notifications, setNotifications] = useState<Notification[]>();
   const [lastId, setLastId] = useState<string>();
   const [isAllShown, setIsAllShown] = useState<boolean>(false);
+  const { socket } = useSocket();
+
   useEffect(() => {
     async function fetchNotifications() {
       if (loggedInUser) {
@@ -32,9 +35,12 @@ export default function AllNotifications(): JSX.Element {
         }
       }
     }
-
     fetchNotifications();
-  }, [loggedInUser]);
+
+    socket?.on('new-notification', (newNotification: Notification) => {
+      setNotifications((oldNotificationsList) => [newNotification, ...(oldNotificationsList as Notification[])]);
+    });
+  }, [socket, loggedInUser]);
 
   useEffect(() => {
     async function markAllNotificationsAsRead() {

--- a/client/src/pages/AllNotifiactions/AllNotifications.tsx
+++ b/client/src/pages/AllNotifiactions/AllNotifications.tsx
@@ -8,15 +8,13 @@ import NotificationsMenuItems from '../../components/NavBar/NotificationsMenu/No
 export default function AllNotifications(): JSX.Element {
   const { loggedInUser } = useAuth();
 
-  const [notifications, setNotifications] = useState<[Notification]>();
+  const [notifications, setNotifications] = useState<Notification[]>();
   const [lastId, setLastId] = useState<string>();
   const [isAllShown, setIsAllShown] = useState<boolean>(false);
   useEffect(() => {
     async function fetchNotifications() {
       if (loggedInUser) {
         const fetchedNotifications = await getAllNotifications();
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        //@ts-ignore
         setNotifications(fetchedNotifications);
         if (fetchedNotifications.length > 1) {
           setLastId(fetchedNotifications[fetchedNotifications.length - 1]._id);
@@ -67,9 +65,7 @@ export default function AllNotifications(): JSX.Element {
               variant="outlined"
               onClick={async () => {
                 const fetchedNotifications = await getAllNotifications(lastId);
-                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                //@ts-ignore
-                setNotifications((old) => [...old, ...fetchedNotifications]);
+                setNotifications((old) => [...(old as Notification[]), ...(fetchedNotifications as Notification[])]);
 
                 if (fetchedNotifications.length > 1) {
                   setLastId(fetchedNotifications[fetchedNotifications.length - 1]._id);

--- a/server/controllers/notification.js
+++ b/server/controllers/notification.js
@@ -1,6 +1,7 @@
 const asyncHandler = require("express-async-handler");
 const Notification = require("../models/Notification");
 const User = require("../models/User");
+const mongoose = require("mongoose");
 
 exports.createNotification = asyncHandler(async (req, res, next) => {
   const { userReceivedId, notificationType, title, description } = req.body;
@@ -36,11 +37,28 @@ exports.markNotificationAsRead = asyncHandler(async (req, res, next) => {
   res.sendStatus(200);
 });
 exports.getAllNotifications = asyncHandler(async (req, res, next) => {
+  const lastId = req.query.id;
   const loggedInUserId = req.user.id;
-  const notifications = await Notification.find({
-    userId: loggedInUserId,
-  }).sort("-createdAt");
-  res.status(200).json(notifications);
+  let notifications;
+  if (lastId === "undefined") {
+    notifications = await Notification.find({
+      userId: loggedInUserId,
+    })
+      .sort("-createdAt")
+      .limit(8);
+
+    return res.status(200).json(notifications);
+  } else {
+    notifications = await Notification.find({
+      userId: loggedInUserId,
+
+      _id: { $lt: mongoose.Types.ObjectId(lastId) },
+    })
+      .sort("-createdAt")
+      .limit(8);
+
+    return res.status(200).json(notifications);
+  }
 });
 exports.getUnreadNotifications = asyncHandler(async (req, res, next) => {
   const loggedInUserId = req.user.id;


### PR DESCRIPTION
### What this PR does (required):
- tried adding pagination to the all notifications page instead of fetching them all at once


### Screenshots / Videos (required):
https://user-images.githubusercontent.com/29197126/133828513-18c64aee-3818-4897-916d-59e5af001654.mov

### Any information needed to test this feature (required):
- go to `http://localhost:3000/notifications` it  should only works if the user has more than 8 notifiactons

### Any issues with the current functionality (optional):
- instead of using [`skip()`](https://stackoverflow.com/a/23640287) I tried using ranges with ids. the down side of ranges is that we can only fetch the next page by id. so I'm not sure if not using skip was the correct choice

